### PR TITLE
[UM-5608] Add privileges information for each Open API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,20 @@ ApiFest Doclet requires the following environment variables:
 
 For both modes:
 
-- mode - the Doclet support two modes in the moment ("mapping" and "doc").They can be comma separated.
+- mode - the Doclet support two modes at the moment ("mapping", "doc" and "openAPI"). They can be comma separated.
 - mapping.version - the version your API will be exposed externally;
-- application.path - the application path used to obtain all application resources, it will be preprended to each internal path;
+- application.path - the application path used to obtain all application resources, it will be prepended to each internal path;
 
-Only for the Doclet "mapping" mode:
+Only for the Doclet "mapping" and "openAPI" mode:
 
 - mapping.filename - the name of the mapping configuration file that will be generated;
 - backend.host - the host(your API is running on) where requests should be translated to;
 - backend.port - the port of the backend.host;
 - defaultActionClass - the fully qualified action class that will be added if no action is declared in Javadoc annotations;
-- defaultFilterClass - the fully qualified filter class that will be added if no filter is declared in Javadoc annotations.
+- defaultFilterClass - the fully qualified filter class that will be added if no filter is declared in Javadoc annotations;
+- customAnnotations - the fully qualified class for custom annotations. If more than one, they must be separated by ".";
+- customAnnotationsAddToDescription - the fully qualified class and its property for custom annotation that will be added 
+to the endpoint description. If more than one, they must be separated by "."
 
 Only for the Doclet "doc" mode:
 
@@ -148,6 +151,7 @@ If your project uses maven, here is an example integration of ApiFest Doclet in 
                     <additionalJOption>-J-DdefaultFilterClass=${defaultFilterClass}</additionalJOption>
                     <additionalJOption>-J-Dmode=${mode}</additionalJOption>
                     <additionalJOption>-J-DcustomAnnotations=annotationAQualifiedName,annotationBQualifiedName:value,annotationBQualifiedName:data</additionalJOption>
+                    <additionalJOption>-J-DcustomAnnotationsAddToDescription=annotationAQualifiedName,annotationBQualifiedName:value,annotationBQualifiedName:data</additionalJOption>
                   </additionalJOptions>
                   <useStandardDocletOptions>false</useStandardDocletOptions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.apifest</groupId>
   <artifactId>apifest-doclet</artifactId>
-  <version>3.0.3</version>
+  <version>3.0.4</version>
 
   <distributionManagement>
     <snapshotRepository>

--- a/src/main/java/com/apifest/doclet/Doclet.java
+++ b/src/main/java/com/apifest/doclet/Doclet.java
@@ -27,6 +27,7 @@ import com.apifest.doclet.option.ApiVersionOption;
 import com.apifest.doclet.option.ApplicationPathOption;
 import com.apifest.doclet.option.BackendHostOption;
 import com.apifest.doclet.option.BackendPortOption;
+import com.apifest.doclet.option.CustomAnnotationAddToDescriptionOption;
 import com.apifest.doclet.option.CustomAnnotationOption;
 import com.apifest.doclet.option.DefaultActionClassOption;
 import com.apifest.doclet.option.DefaultFilterClassOption;
@@ -93,13 +94,14 @@ public class Doclet implements jdk.javadoc.doclet.Doclet {
     MappingVersionOption mappingVersionOption = new MappingVersionOption();
     ModeOption modeOption = new ModeOption();
     CustomAnnotationOption customAnnotationOption = new CustomAnnotationOption();
+    CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = new CustomAnnotationAddToDescriptionOption();
     ApiVersionOption apiVersionOption = new ApiVersionOption();
     ApiTestServerOption apiTestServerOption = new ApiTestServerOption();
     private final Set<Option> supportedOptions = Set.of(
             applicationPathOption, backendHostOption, backendPortOption,
             defaultActionClassOption, defaultFilterClassOption, mappingDocsFilenameOption,
             mappingFilenameOption, mappingVersionOption, modeOption,
-            customAnnotationOption, apiVersionOption, apiTestServerOption
+            customAnnotationOption, customAnnotationAddToDescriptionOption, apiVersionOption, apiTestServerOption
     );
 
     OpenAPIGenerator openAPIGenerator;
@@ -210,7 +212,7 @@ public class Doclet implements jdk.javadoc.doclet.Doclet {
             }
             if (modeOption.getDocletModes().contains(DocletMode.OPEN_API)) {
                 openAPIGenerator = new OpenAPIGenerator(apiVersionOption.getApiVersion(), apiTestServerOption.getApiTestServer());
-                openAPIGenerator.generateOpenAPIFile(classes, parsedEndpoints, "openAPI-" + mappingDocsFilenameOption.getMappingDocsFilename());
+                openAPIGenerator.generateOpenAPIFile(classes, parsedEndpoints, "openAPI-" + mappingDocsFilenameOption.getMappingDocsFilename(), customAnnotationAddToDescriptionOption);
             }
         } catch (JsonGenerationException e) {
             System.out.println("ERROR: cannot create mapping documentation file, " + e.getMessage());

--- a/src/main/java/com/apifest/doclet/OpenAPIGenerator.java
+++ b/src/main/java/com/apifest/doclet/OpenAPIGenerator.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
-import java.util.regex.Pattern;
 
 public class OpenAPIGenerator {
 
@@ -155,7 +154,6 @@ public class OpenAPIGenerator {
             StringBuilder description = new StringBuilder();
             if (operation.getDescription() != null) {
                 description.append(operation.getDescription());
-                description.append(LINE_SEPARATOR);
             }
 
             for (Map.Entry entry : endpointDocumentation.getCustomProperties().entrySet()) {
@@ -163,8 +161,10 @@ public class OpenAPIGenerator {
                     customAnnotationAddToDescriptionOption.getCustomAnnotationsAddToDescription().containsKey(entry.getKey())) {
                     // get the annotation class only
                     String annotationName = getClassName(entry.getKey().toString());
-                    description.append(annotationName + " " + entry.getValue());
-                    description.append(LINE_SEPARATOR);
+                    if (annotationName != null) {
+                        description.append(LINE_SEPARATOR);
+                        description.append(annotationName + " " + entry.getValue());
+                    }
                 }
             }
             operation.setDescription(description.toString());

--- a/src/main/java/com/apifest/doclet/OpenAPIGenerator.java
+++ b/src/main/java/com/apifest/doclet/OpenAPIGenerator.java
@@ -40,7 +40,7 @@ public class OpenAPIGenerator {
 
     protected static final String NOTO_SECURITY_SCHEME = "noto-oauth";
     protected static final String LINE_SEPARATOR = "\n\n";
-    protected static final String CLASSNAME_PATTERN = "^[A-Z]+\\w+";
+    protected static final String CLASSNAME_PATTERN = "^[A-Z]+[a-zA-Z\\d_$]*";
     protected String apiVersion = null;
     protected String apiTestServer = null;
 
@@ -155,10 +155,9 @@ public class OpenAPIGenerator {
             if (operation.getDescription() != null) {
                 description.append(operation.getDescription());
             }
-
             for (Map.Entry entry : endpointDocumentation.getCustomProperties().entrySet()) {
                 if (customAnnotationAddToDescriptionOption.getCustomAnnotationsAddToDescription() != null &&
-                    customAnnotationAddToDescriptionOption.getCustomAnnotationsAddToDescription().containsKey(entry.getKey())) {
+                    customAnnotationAddToDescriptionOption.getCustomAnnotationsAddToDescription().contains(entry.getKey())) {
                     // get the annotation class only
                     String annotationName = getClassName(entry.getKey().toString());
                     if (annotationName != null) {

--- a/src/main/java/com/apifest/doclet/option/CustomAnnotationAddToDescriptionOption.java
+++ b/src/main/java/com/apifest/doclet/option/CustomAnnotationAddToDescriptionOption.java
@@ -3,13 +3,11 @@ package com.apifest.doclet.option;
 import jdk.javadoc.doclet.Doclet;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class CustomAnnotationAddToDescriptionOption implements Doclet.Option {
-    private Map<String, List<String>> customAnnotationsAddToDescription = new HashMap<>();
+
+    private List<String> customAnnotationsAddToDescription = new ArrayList<>();
 
     @Override
     public int getArgumentCount() {
@@ -40,18 +38,12 @@ public class CustomAnnotationAddToDescriptionOption implements Doclet.Option {
     public boolean process(String option, List<String> arguments) {
         String customAnnotationsValue = arguments.get(0);
         for (String annotation : customAnnotationsValue.split(",")) {
-            if (annotation.contains(":")) {
-                String[] tokens = annotation.split(":");
-                List<String> annotationAttributeList = customAnnotationsAddToDescription.computeIfAbsent(tokens[0], k -> new ArrayList<>());
-                annotationAttributeList.add(tokens[1]);
-            } else {
-                customAnnotationsAddToDescription.put(annotation, Collections.emptyList());
-            }
+            customAnnotationsAddToDescription.add(annotation);
         }
         return true;
     }
 
-    public Map<String, List<String>> getCustomAnnotationsAddToDescription() {
+    public List<String> getCustomAnnotationsAddToDescription() {
         return customAnnotationsAddToDescription;
     }
 }

--- a/src/main/java/com/apifest/doclet/option/CustomAnnotationAddToDescriptionOption.java
+++ b/src/main/java/com/apifest/doclet/option/CustomAnnotationAddToDescriptionOption.java
@@ -1,0 +1,58 @@
+package com.apifest.doclet.option;
+
+import jdk.javadoc.doclet.Doclet;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CustomAnnotationAddToDescriptionOption implements Doclet.Option {
+    private Map<String, List<String>> customAnnotationsAddToDescription = new HashMap<>();
+
+    @Override
+    public int getArgumentCount() {
+        return 1;  // The option requires one argument
+    }
+
+    @Override
+    public String getDescription() {
+        return "Sets the custom annotations the values of which will be added to the operation description";
+    }
+
+    @Override
+    public Kind getKind() {
+        return Doclet.Option.Kind.STANDARD;
+    }
+
+    @Override
+    public List<String> getNames() {
+        return List.of("-customAnnotationsAddToDescription", "--custom-annotations-add-to_descr");
+    }
+
+    @Override
+    public String getParameters() {
+        return "annotations";
+    }
+
+    @Override
+    public boolean process(String option, List<String> arguments) {
+        String customAnnotationsValue = arguments.get(0);
+        System.out.println("process custom annotations add to description");
+        for (String annotation : customAnnotationsValue.split(",")) {
+            if (annotation.contains(":")) {
+                String[] tokens = annotation.split(":");
+                List<String> annotationAttributeList = customAnnotationsAddToDescription.computeIfAbsent(tokens[0], k -> new ArrayList<>());
+                annotationAttributeList.add(tokens[1]);
+            } else {
+                customAnnotationsAddToDescription.put(annotation, Collections.emptyList());
+            }
+        }
+        return true;
+    }
+
+    public Map<String, List<String>> getCustomAnnotationsAddToDescription() {
+        return customAnnotationsAddToDescription;
+    }
+}

--- a/src/main/java/com/apifest/doclet/option/CustomAnnotationAddToDescriptionOption.java
+++ b/src/main/java/com/apifest/doclet/option/CustomAnnotationAddToDescriptionOption.java
@@ -39,7 +39,6 @@ public class CustomAnnotationAddToDescriptionOption implements Doclet.Option {
     @Override
     public boolean process(String option, List<String> arguments) {
         String customAnnotationsValue = arguments.get(0);
-        System.out.println("process custom annotations add to description");
         for (String annotation : customAnnotationsValue.split(",")) {
             if (annotation.contains(":")) {
                 String[] tokens = annotation.split(":");

--- a/src/test/java/com/apifest/doclet/OpenAPIGeneratorTest.java
+++ b/src/test/java/com/apifest/doclet/OpenAPIGeneratorTest.java
@@ -437,23 +437,24 @@ public class OpenAPIGeneratorTest {
     }
 
     @Test
-    public void when_addCustomPropertiesToDescription_invoke_getClassName() {
+    public void when_addCustomPropertiesToDescription_invoke_getClassName_and_add_to_description() {
         // GIVEN
         Operation operation = new Operation();
         String operationDescr = "Test endpoint description";
         operation.setDescription(operationDescr);
 
-        String customAnnotationValue = "com.umbrella.guardian.mappings.RequiredPrivileges.names";
+        String customAnnotation = "com.umbrella.guardian.mappings.RequiredPrivileges.names";
         Map<String, String> customProperties = new HashMap<>();
-        customProperties.put(customAnnotationValue, "VIEW_REPORTS,MANAGE_REPORTS");
+        String customAnnotationValue = "VIEW_REPORTS,MANAGE_REPORTS";
+        customProperties.put(customAnnotation, customAnnotationValue);
         MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
         endpointDocumentation.setCustomProperties(customProperties);
 
         CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = new CustomAnnotationAddToDescriptionOption();
-        String customAnnotation = "customAnnotationsAddToDescription";
-        customAnnotationAddToDescriptionOption.process(customAnnotation, Lists.newArrayList(customAnnotationValue));
-        String expectedDescription = operationDescr + OpenAPIGenerator.LINE_SEPARATOR + "RequiredPrivileges " +
-                "VIEW_REPORTS,MANAGE_REPORTS";
+        String customAnnotationToDescr = "customAnnotationsAddToDescription";
+        customAnnotationAddToDescriptionOption.process(customAnnotationToDescr, Lists.newArrayList(customAnnotation));
+        String expectedDescription = operationDescr + OpenAPIGenerator.LINE_SEPARATOR +
+                "RequiredPrivileges " + customAnnotationValue;
 
         OpenAPIGenerator spyGenerator = spy(new OpenAPIGenerator("1.0", ""));
 
@@ -461,7 +462,42 @@ public class OpenAPIGeneratorTest {
         spyGenerator.addCustomPropertiesToDescription(operation, endpointDocumentation, customAnnotationAddToDescriptionOption);
 
         // THEN
-        verify(spyGenerator).getClassName(customAnnotationValue);
+        verify(spyGenerator).getClassName(customAnnotation);
+        assertEquals(operation.getDescription(), expectedDescription);
+    }
+
+    @Test
+    public void when_two_custom_propertiesToDescription_invoke_getClassName_and_add_to_description() {
+        // GIVEN
+        Operation operation = new Operation();
+        String operationDescr = "Test endpoint description";
+        operation.setDescription(operationDescr);
+
+        String firstAnnotation = "com.umbrella.guardian.mappings.RequiredPrivileges.names";
+        String secondAnnotation = "com.umbrella.guardian.mappings.RequiredFeatures.names";
+        Map<String, String> customProperties = new HashMap<>();
+        String firstAnnotationValue = "VIEW_REPORTS,MANAGE_REPORTS";
+        String secondAnnotationValue = "REPORTING";
+        customProperties.put(firstAnnotation, firstAnnotationValue);
+        customProperties.put(secondAnnotation, secondAnnotationValue);
+        MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
+        endpointDocumentation.setCustomProperties(customProperties);
+
+        CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = new CustomAnnotationAddToDescriptionOption();
+        String customAnnotation = "customAnnotationsAddToDescription";
+        customAnnotationAddToDescriptionOption.process(customAnnotation, Lists.newArrayList(firstAnnotation + "," + secondAnnotation));
+        String expectedDescription = operationDescr + OpenAPIGenerator.LINE_SEPARATOR +
+                "RequiredPrivileges " + firstAnnotationValue + OpenAPIGenerator.LINE_SEPARATOR +
+                "RequiredFeatures " + secondAnnotationValue;
+
+        OpenAPIGenerator spyGenerator = spy(new OpenAPIGenerator("1.0", ""));
+
+        // WHEN
+        spyGenerator.addCustomPropertiesToDescription(operation, endpointDocumentation, customAnnotationAddToDescriptionOption);
+
+        // THEN
+        verify(spyGenerator).getClassName(firstAnnotation);
+        verify(spyGenerator).getClassName(secondAnnotation);
         assertEquals(operation.getDescription(), expectedDescription);
     }
 

--- a/src/test/java/com/apifest/doclet/OpenAPIGeneratorTest.java
+++ b/src/test/java/com/apifest/doclet/OpenAPIGeneratorTest.java
@@ -312,7 +312,7 @@ public class OpenAPIGeneratorTest {
         endpointDocumentation.setResultParamsDocumentation(resultParamsList);
 
         // WHEN
-        generator.updateOperationDocumentation(operation, endpointDocumentation);
+        generator.updateOperationDocumentation(operation, endpointDocumentation, null);
 
         // THEN
         assertEquals(operation.getDescription(), description);
@@ -337,10 +337,10 @@ public class OpenAPIGeneratorTest {
         endpointDocumentation.setMethod("POST");
 
         // WHEN
-        spyGenerator.createPathItemDocumentation(pathItem, endpointDocumentation);
+        spyGenerator.createPathItemDocumentation(pathItem, endpointDocumentation, null);
 
         // THEN
-        verify(spyGenerator).updateOperationDocumentation(any(), eq(endpointDocumentation));
+        verify(spyGenerator).updateOperationDocumentation(any(), eq(endpointDocumentation), eq(null));
         verify(spyGenerator).addOperationToPathItem(eq(pathItem), any(), eq(endpointDocumentation));
     }
 
@@ -351,75 +351,13 @@ public class OpenAPIGeneratorTest {
         PathItem pathItem = new PathItem();
         MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
         endpointDocumentation.setMethod("POST");
-        doNothing().when(spyGenerator).createPathItemDocumentation(pathItem, endpointDocumentation);
+        doNothing().when(spyGenerator).createPathItemDocumentation(pathItem, endpointDocumentation, null);
 
         // WHEN
-        spyGenerator.addDocumentationToPathItem(pathItem, endpointDocumentation);
+        spyGenerator.addDocumentationToPathItem(pathItem, endpointDocumentation, null);
 
         // THEN
-        verify(spyGenerator).createPathItemDocumentation(pathItem, endpointDocumentation);
-    }
-
-    @Test
-    public void test_generateOpenAPI_file() {
-        // GIVEN
-        Set<Class<?>> classSet = new HashSet<>();
-        classSet.add(CreateUserRequest.class);
-        classSet.add(Users.class);
-        List<ParsedEndpoint> parsedEndpoints = new ArrayList<>();
-        ParsedEndpoint createUserEndpoint = new ParsedEndpoint();
-        createUserEndpoint.setEndpointPathWithoutVersion("/user");
-        MappingEndpointDocumentation mappingEndpointDocumentation = new MappingEndpointDocumentation();
-        mappingEndpointDocumentation.setGroup("User");
-        mappingEndpointDocumentation.setSummary("Create a user");
-        mappingEndpointDocumentation.setDescription("This web service creates a new user");
-        mappingEndpointDocumentation.setScope("umbrella");
-        mappingEndpointDocumentation.setMethod("PUT");
-        createUserEndpoint.setMappingEndpointDocumentation(mappingEndpointDocumentation);
-
-        MappingEndpoint mappingEndpoint = new MappingEndpoint();
-        mappingEndpoint.setAuthType("user");
-        mappingEndpoint.setScope("umbrella");
-        mappingEndpoint.setInternalEndpoint("/user/{organization}");
-        mappingEndpoint.setExternalEndpoint("/1.0/users");
-        createUserEndpoint.setMappingEndpoint(mappingEndpoint);
-        parsedEndpoints.add(createUserEndpoint);
-
-        ParsedEndpoint getUserInfoEndpoint = new ParsedEndpoint();
-        getUserInfoEndpoint.setEndpointPathWithoutVersion("/user");
-        MappingEndpointDocumentation mappingEndpointDocumentation2 = new MappingEndpointDocumentation();
-        mappingEndpointDocumentation2.setGroup("User");
-        mappingEndpointDocumentation2.setSummary("Current user's access information");
-        mappingEndpointDocumentation2.setDescription("This web service returns information about the user");
-        mappingEndpointDocumentation2.setScope("umbrella");
-        mappingEndpointDocumentation2.setMethod("GET");
-        getUserInfoEndpoint.setMappingEndpointDocumentation(mappingEndpointDocumentation2);
-
-        MappingEndpoint mappingEndpoint2 = new MappingEndpoint();
-        mappingEndpoint2.setAuthType("user");
-        mappingEndpoint2.setScope("umbrella");
-        mappingEndpoint2.setInternalEndpoint("/user");
-        mappingEndpoint2.setExternalEndpoint("/1.0/users");
-        getUserInfoEndpoint.setMappingEndpoint(mappingEndpoint2);
-        parsedEndpoints.add(getUserInfoEndpoint);
-
-        // WHEN
-        OpenAPI openAPI = generator.generateOpenAPI(classSet, parsedEndpoints);
-
-        // THEN
-        PathItem path = openAPI.getPaths().get("/user");
-        Operation getUserOperation = path.getGet();
-        assertNotNull(getUserOperation);
-        assertEquals(getUserOperation.getSummary(), "Current user's access information");
-        assertEquals(getUserOperation.getDescription(), "This web service returns information about the user");
-        assertEquals(getUserOperation.getTags().get(0), "User");
-        assertEquals(getUserOperation.getSecurity().get(0).get(OpenAPIGenerator.NOTO_SECURITY_SCHEME).get(0), "umbrella");
-
-        Operation putUserOperation = path.getPut();
-        assertNotNull(putUserOperation);
-        assertEquals(putUserOperation.getSummary(), "Create a user");
-        assertEquals(putUserOperation.getDescription(), "This web service creates a new user");
-        assertEquals(putUserOperation.getTags().get(0), "User");
+        verify(spyGenerator).createPathItemDocumentation(pathItem, endpointDocumentation, null);
     }
 
     @Test
@@ -429,12 +367,12 @@ public class OpenAPIGeneratorTest {
         Set<Class<?>> classSet = new HashSet<>();
         List<ParsedEndpoint> parsedEndpoints = new ArrayList<>();
         OpenAPI openAPI = new OpenAPI();
-        when(spyGenerator.generateOpenAPI(classSet, parsedEndpoints)).thenReturn(openAPI);
+        when(spyGenerator.generateOpenAPI(classSet, parsedEndpoints, null)).thenReturn(openAPI);
 
         // WHEN
-        generator.generateOpenAPIFile(classSet, parsedEndpoints, "openAPI-test.json");
+        generator.generateOpenAPIFile(classSet, parsedEndpoints, "openAPI-test.json", null);
 
         // THEN
-        verify(spyGenerator).generateOpenAPI(classSet, parsedEndpoints);
+        verify(spyGenerator).generateOpenAPI(classSet, parsedEndpoints, null);
     }
 }

--- a/src/test/java/com/apifest/doclet/OpenAPIGeneratorTest.java
+++ b/src/test/java/com/apifest/doclet/OpenAPIGeneratorTest.java
@@ -38,7 +38,14 @@ import static org.mockito.Mockito.mock;
 
 public class OpenAPIGeneratorTest {
 
-    OpenAPIGenerator generator;
+    private static final String CUSTOM_ANNOTATION_VALUE = "VIEW_REPORTS,MANAGE_REPORTS";
+    private static final String CUSTOM_ANNOTATION = "com.umbrella.guardian.mappings.RequiredPrivileges.names";
+    private static final String OPERATION_DESCR = "Test endpoint description";
+
+    private static final String ADDITIONAL_CUSTOM_ANNOTATION = "com.umbrella.guardian.mappings.RequiredFeatures.names";
+    private static final String ADDITIONAL_CUSTOM_ANNOTATION_VALUE = "REPORTING";
+
+            OpenAPIGenerator generator;
 
     @BeforeMethod
     public void setup() {
@@ -439,56 +446,36 @@ public class OpenAPIGeneratorTest {
     @Test
     public void when_addCustomPropertiesToDescription_invoke_getClassName_and_add_to_description() {
         // GIVEN
-        Operation operation = new Operation();
-        String operationDescr = "Test endpoint description";
-        operation.setDescription(operationDescr);
-
-        String customAnnotation = "com.umbrella.guardian.mappings.RequiredPrivileges.names";
-        Map<String, String> customProperties = new HashMap<>();
-        String customAnnotationValue = "VIEW_REPORTS,MANAGE_REPORTS";
-        customProperties.put(customAnnotation, customAnnotationValue);
-        MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
-        endpointDocumentation.setCustomProperties(customProperties);
-
-        CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = new CustomAnnotationAddToDescriptionOption();
-        String customAnnotationToDescr = "customAnnotationsAddToDescription";
-        customAnnotationAddToDescriptionOption.process(customAnnotationToDescr, Lists.newArrayList(customAnnotation));
-        String expectedDescription = operationDescr + OpenAPIGenerator.LINE_SEPARATOR +
-                "RequiredPrivileges " + customAnnotationValue;
+        Operation operation = createOperation(OPERATION_DESCR);
+        MappingEndpointDocumentation mappingEndpointDocumentation = createMappingEndpointDocumentation();
+        CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = createCustomAnnotationAddToDescriptionOption();
 
         OpenAPIGenerator spyGenerator = spy(new OpenAPIGenerator("1.0", ""));
 
         // WHEN
-        spyGenerator.addCustomPropertiesToDescription(operation, endpointDocumentation, customAnnotationAddToDescriptionOption);
+        spyGenerator.addCustomPropertiesToDescription(operation, mappingEndpointDocumentation, customAnnotationAddToDescriptionOption);
 
         // THEN
-        verify(spyGenerator).getClassName(customAnnotation);
+        String expectedDescription = OPERATION_DESCR + OpenAPIGenerator.LINE_SEPARATOR +
+                "RequiredPrivileges " + CUSTOM_ANNOTATION_VALUE;
+        verify(spyGenerator).getClassName(CUSTOM_ANNOTATION);
         assertEquals(operation.getDescription(), expectedDescription);
     }
 
     @Test
     public void when_two_custom_propertiesToDescription_invoke_getClassName_and_add_to_description() {
         // GIVEN
-        Operation operation = new Operation();
-        String operationDescr = "Test endpoint description";
-        operation.setDescription(operationDescr);
+        Operation operation = createOperation(OPERATION_DESCR);
 
-        String firstAnnotation = "com.umbrella.guardian.mappings.RequiredPrivileges.names";
-        String secondAnnotation = "com.umbrella.guardian.mappings.RequiredFeatures.names";
         Map<String, String> customProperties = new HashMap<>();
-        String firstAnnotationValue = "VIEW_REPORTS,MANAGE_REPORTS";
-        String secondAnnotationValue = "REPORTING";
-        customProperties.put(firstAnnotation, firstAnnotationValue);
-        customProperties.put(secondAnnotation, secondAnnotationValue);
+        customProperties.put(CUSTOM_ANNOTATION, CUSTOM_ANNOTATION_VALUE);
+        customProperties.put(ADDITIONAL_CUSTOM_ANNOTATION, ADDITIONAL_CUSTOM_ANNOTATION_VALUE);
         MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
         endpointDocumentation.setCustomProperties(customProperties);
 
         CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = new CustomAnnotationAddToDescriptionOption();
         String customAnnotation = "customAnnotationsAddToDescription";
-        customAnnotationAddToDescriptionOption.process(customAnnotation, Lists.newArrayList(firstAnnotation + "," + secondAnnotation));
-        String expectedDescription = operationDescr + OpenAPIGenerator.LINE_SEPARATOR +
-                "RequiredPrivileges " + firstAnnotationValue + OpenAPIGenerator.LINE_SEPARATOR +
-                "RequiredFeatures " + secondAnnotationValue;
+        customAnnotationAddToDescriptionOption.process(customAnnotation, Lists.newArrayList(CUSTOM_ANNOTATION + "," + ADDITIONAL_CUSTOM_ANNOTATION));
 
         OpenAPIGenerator spyGenerator = spy(new OpenAPIGenerator("1.0", ""));
 
@@ -496,21 +483,20 @@ public class OpenAPIGeneratorTest {
         spyGenerator.addCustomPropertiesToDescription(operation, endpointDocumentation, customAnnotationAddToDescriptionOption);
 
         // THEN
-        verify(spyGenerator).getClassName(firstAnnotation);
-        verify(spyGenerator).getClassName(secondAnnotation);
+        String expectedDescription = OPERATION_DESCR + OpenAPIGenerator.LINE_SEPARATOR +
+                "RequiredPrivileges " + CUSTOM_ANNOTATION_VALUE + OpenAPIGenerator.LINE_SEPARATOR +
+                "RequiredFeatures " + ADDITIONAL_CUSTOM_ANNOTATION_VALUE;
+        verify(spyGenerator).getClassName(CUSTOM_ANNOTATION);
+        verify(spyGenerator).getClassName(ADDITIONAL_CUSTOM_ANNOTATION);
         assertEquals(operation.getDescription(), expectedDescription);
     }
 
     @Test
     public void when_no_custom_properties_addCustomPropertiesToDescription_do_nothing() {
         // GIVEN
-        Operation operation = new Operation();
-        String operationDescr = "Test endpoint description";
-        operation.setDescription(operationDescr);
-
+        Operation operation = createOperation(OPERATION_DESCR);
         MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
         endpointDocumentation.setCustomProperties(null);
-
         CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = new CustomAnnotationAddToDescriptionOption();
 
         OpenAPIGenerator spyGenerator = spy(new OpenAPIGenerator("1.0", ""));
@@ -519,27 +505,15 @@ public class OpenAPIGeneratorTest {
         spyGenerator.addCustomPropertiesToDescription(operation, endpointDocumentation, customAnnotationAddToDescriptionOption);
 
         // THEN
-        assertEquals(operation.getDescription(), operationDescr);
+        assertEquals(operation.getDescription(), OPERATION_DESCR);
     }
 
     @Test
     public void when_addCustomPropertiesToDescription_with_no_operation_description() {
         // GIVEN
-        Operation operation = new Operation();
-        String operationDescr = "Test endpoint description";
-        operation.setDescription(operationDescr);
-
-        String customAnnotationValue = "com.umbrella.guardian.mappings.RequiredPrivileges.names";
-        Map<String, String> customProperties = new HashMap<>();
-        customProperties.put(customAnnotationValue, "VIEW_REPORTS,MANAGE_REPORTS");
-        MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
-        endpointDocumentation.setCustomProperties(customProperties);
-
-        CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = new CustomAnnotationAddToDescriptionOption();
-        String customAnnotation = "customAnnotationsAddToDescription";
-        customAnnotationAddToDescriptionOption.process(customAnnotation, Lists.newArrayList(customAnnotationValue));
-        String expectedDescription = operationDescr + OpenAPIGenerator.LINE_SEPARATOR + "RequiredPrivileges " +
-                "VIEW_REPORTS,MANAGE_REPORTS";
+        Operation operation = createOperation(OPERATION_DESCR);
+        MappingEndpointDocumentation endpointDocumentation = createMappingEndpointDocumentation();
+        CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = createCustomAnnotationAddToDescriptionOption();
 
         OpenAPIGenerator spyGenerator = spy(new OpenAPIGenerator("1.0", ""));
 
@@ -547,26 +521,22 @@ public class OpenAPIGeneratorTest {
         spyGenerator.addCustomPropertiesToDescription(operation, endpointDocumentation, customAnnotationAddToDescriptionOption);
 
         // THEN
-        verify(spyGenerator).getClassName(customAnnotationValue);
+        String expectedDescription = OPERATION_DESCR + OpenAPIGenerator.LINE_SEPARATOR + "RequiredPrivileges " +
+                "VIEW_REPORTS,MANAGE_REPORTS";
+        verify(spyGenerator).getClassName(CUSTOM_ANNOTATION);
         assertEquals(operation.getDescription(), expectedDescription);
     }
 
     @Test
     public void when_no_extracted_className_addCustomPropertiesToDescription_do_not_add_custom_annotation() {
         // GIVEN
-        Operation operation = new Operation();
-        String operationDescr = "Test endpoint description";
-        operation.setDescription(operationDescr);
+        Operation operation = createOperation(OPERATION_DESCR);
 
-        String customAnnotationValue = "names";
-        Map<String, String> customProperties = new HashMap<>();
-        customProperties.put(customAnnotationValue, "VIEW_REPORTS,MANAGE_REPORTS");
-        MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
-        endpointDocumentation.setCustomProperties(customProperties);
+        String customAnnotation = "names";
+        String customAnnotationValue = "VIEW_REPORTS,MANAGE_REPORTS";
+        MappingEndpointDocumentation endpointDocumentation = createMappingEndpointDocumentation(customAnnotation, customAnnotationValue);
 
-        CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = new CustomAnnotationAddToDescriptionOption();
-        String customAnnotation = "customAnnotationsAddToDescription";
-        customAnnotationAddToDescriptionOption.process(customAnnotation, Lists.newArrayList(customAnnotationValue));
+        CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = createCustomAnnotationAddToDescriptionOption();
 
         OpenAPIGenerator spyGenerator = spy(new OpenAPIGenerator("1.0", ""));
 
@@ -574,13 +544,13 @@ public class OpenAPIGeneratorTest {
         spyGenerator.addCustomPropertiesToDescription(operation, endpointDocumentation, customAnnotationAddToDescriptionOption);
 
         // THEN
-        assertEquals(operation.getDescription(), operationDescr);
+        assertEquals(operation.getDescription(), OPERATION_DESCR);
     }
 
     @Test
     public void when_updateOperationDocumentation_invoke_addCustomPropertiesToDescription() {
         // GIVEN
-        Operation operation = new Operation();
+        Operation operation = createOperation(null);
         MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
         CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = new CustomAnnotationAddToDescriptionOption();
         OpenAPIGenerator spyGenerator = spy(new OpenAPIGenerator("1.0", ""));
@@ -593,4 +563,32 @@ public class OpenAPIGeneratorTest {
         verify(spyGenerator).addCustomPropertiesToDescription(operation, endpointDocumentation, customAnnotationAddToDescriptionOption);
     }
 
+    private Operation createOperation(String description) {
+        Operation operation = new Operation();
+        operation.setDescription(description);
+        return operation;
+    }
+
+    private MappingEndpointDocumentation createMappingEndpointDocumentation(String customAnnotation, String customAnnotationValue) {
+        Map<String, String> customProperties = new HashMap<>();
+        customProperties.put(customAnnotation, customAnnotationValue);
+        MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
+        endpointDocumentation.setCustomProperties(customProperties);
+        return endpointDocumentation;
+    }
+
+    private MappingEndpointDocumentation createMappingEndpointDocumentation() {
+        Map<String, String> customProperties = new HashMap<>();
+        customProperties.put(CUSTOM_ANNOTATION, CUSTOM_ANNOTATION_VALUE);
+        MappingEndpointDocumentation endpointDocumentation = new MappingEndpointDocumentation();
+        endpointDocumentation.setCustomProperties(customProperties);
+        return endpointDocumentation;
+    }
+
+    private CustomAnnotationAddToDescriptionOption createCustomAnnotationAddToDescriptionOption() {
+        CustomAnnotationAddToDescriptionOption customAnnotationAddToDescriptionOption = new CustomAnnotationAddToDescriptionOption();
+        String customAnnotationAddToDescr = "customAnnotationsAddToDescription";
+        customAnnotationAddToDescriptionOption.process(customAnnotationAddToDescr, Lists.newArrayList(CUSTOM_ANNOTATION));
+        return customAnnotationAddToDescriptionOption;
+    }
 }


### PR DESCRIPTION
The privileges for an endpoint will be added to the endpoint description.
In order to generate the openAPI with Privileges, one should add the following argument in guardian/pom.xml:
<additionalOption>-customAnnotationsAddToDescription com.umbrella.guardian.mappings.RequiredPrivileges.names</additionalOption>
where the value is the class used for the custom annotation along with the property that will be added to the description.

If we decide to display the required features later, we need only to add the following to  customAnnotationsAddToDescription otpion: 
com.umbrella.guardian.mappings.RequiredFeatures.names (using comma as a separator).